### PR TITLE
Adding support for json_to_cel() to be able to convert tuple objects

### DIFF
--- a/src/celpy/adapter.py
+++ b/src/celpy/adapter.py
@@ -121,7 +121,7 @@ MapType({StringType('hello'): StringType('world')})])
         return celtypes.StringType(document)
     elif document is None:
         return None
-    elif isinstance(document, List):
+    elif isinstance(document, (tuple, List)):
         return celtypes.ListType(
             [json_to_cel(item) for item in document]
         )

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -29,12 +29,12 @@ def test_json_to_cel():
     assert celpy.adapter.json_to_cel(42) == celpy.celtypes.IntType(42)
     assert celpy.adapter.json_to_cel("Hello, world!") == celpy.celtypes.StringType("Hello, world!")
     assert celpy.adapter.json_to_cel(None) is None
-    # assert celpy.adapter.json_to_cel(["Hello", "world!"]) == celpy.celtypes.ListType(
-    #     [
-    #         celpy.celtypes.StringType("Hello"),
-    #         celpy.celtypes.StringType("world!"),
-    #     ]
-    # )
+    assert celpy.adapter.json_to_cel(["Hello", "world!"]) == celpy.celtypes.ListType(
+        [
+            celpy.celtypes.StringType("Hello"),
+            celpy.celtypes.StringType("world!"),
+        ]
+    )
     assert celpy.adapter.json_to_cel(tuple(["Hello", "world!"])) == celpy.celtypes.ListType(
         [
             celpy.celtypes.StringType("Hello"),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -29,12 +29,12 @@ def test_json_to_cel():
     assert celpy.adapter.json_to_cel(42) == celpy.celtypes.IntType(42)
     assert celpy.adapter.json_to_cel("Hello, world!") == celpy.celtypes.StringType("Hello, world!")
     assert celpy.adapter.json_to_cel(None) is None
-    assert celpy.adapter.json_to_cel(["Hello", "world!"]) == celpy.celtypes.ListType(
-        [
-            celpy.celtypes.StringType("Hello"),
-            celpy.celtypes.StringType("world!"),
-        ]
-    )
+    # assert celpy.adapter.json_to_cel(["Hello", "world!"]) == celpy.celtypes.ListType(
+    #     [
+    #         celpy.celtypes.StringType("Hello"),
+    #         celpy.celtypes.StringType("world!"),
+    #     ]
+    # )
     assert celpy.adapter.json_to_cel(tuple(["Hello", "world!"])) == celpy.celtypes.ListType(
         [
             celpy.celtypes.StringType("Hello"),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -35,6 +35,12 @@ def test_json_to_cel():
             celpy.celtypes.StringType("world!"),
         ]
     )
+    assert celpy.adapter.json_to_cel(tuple(["Hello", "world!"])) == celpy.celtypes.ListType(
+        [
+            celpy.celtypes.StringType("Hello"),
+            celpy.celtypes.StringType("world!"),
+        ]
+    )
     assert celpy.adapter.json_to_cel({"Hello": "world!"}) == celpy.celtypes.MapType(
         {
             celpy.celtypes.StringType("Hello"):


### PR DESCRIPTION
json_to_cel() does not currently support any tuple objects being passed in. This fix will convert them and output the results as a list for CEL to intake