### PR TITLE
Updated absent() and present() to return a CEL BoolType object rather than a Python Boolean object

### DIFF
--- a/src/celpy/c7nlib.py
+++ b/src/celpy/c7nlib.py
@@ -505,11 +505,11 @@ def version(
 
 
 def present(value: celtypes.StringType,) -> celtypes.Value:
-    return cast(celtypes.Value, bool(value))
+    return celtypes.BoolType(bool(value))
 
 
 def absent(value: celtypes.StringType,) -> celtypes.Value:
-    return cast(celtypes.Value, not bool(value))
+    return celtypes.BoolType(not bool(value))
 
 
 def text_from(url: celtypes.StringType,) -> celtypes.Value:


### PR DESCRIPTION
Previously, using the present() or absent() functions would return Python Boolean objects. Using present() or absent() within logical evaluators (ternary, &&, ||) would thus try to compare this Python Boolean object with celtypes.BoolType objects, which would raise a CEL TypeError.

This code change casts the returned Python Boolean object from both present() and absent() into a celtypes.BoolType object, resolving the TypeError.