### PR TITLE
Adding c7nlib support for Custodian to enable get_related_kms_keys()

### DIFF
--- a/src/celpy/c7nlib.py
+++ b/src/celpy/c7nlib.py
@@ -897,6 +897,14 @@ def get_related_vpc(resource: celtypes.MapType,) -> celtypes.Value:
     return json_to_cel(vpc)
 
 
+def get_related_kms_keys(resource: celtypes.MapType,) -> celtypes.Value:
+    """
+    Reach into C7N and make a get_related_kms_keys() request using the current C7N filter.
+    """
+    vpc = C7N.filter.get_related_kms_keys(resource)
+    return json_to_cel(vpc)
+
+
 def security_group(security_group_id: celtypes.MapType,) -> celtypes.Value:
     """
     Reach into C7N and make a get_related() request using the current C7N filter to get
@@ -1457,6 +1465,7 @@ DECLARATIONS: Dict[str, Annotation] = {
     "get_related_igws": celtypes.FunctionType,
     "get_related_security_configs": celtypes.FunctionType,
     "get_related_vpc": celtypes.FunctionType,
+    "get_related_kms_keys": celtypes.FunctionType,
     "get_vpcs": celtypes.FunctionType,
     "get_vpces": celtypes.FunctionType,
     "get_orgids": celtypes.FunctionType,
@@ -1521,6 +1530,7 @@ FUNCTIONS: Dict[str, ExtFunction] = {
         get_related_igws,
         get_related_security_configs,
         get_related_vpc,
+        get_related_kms_keys,
         get_vpcs,
         get_vpces,
         get_orgids,

--- a/tests/test_c7nlib.py
+++ b/tests/test_c7nlib.py
@@ -529,7 +529,7 @@ def celfilter_instance():
         get_related_igws = Mock(return_value=[str(sentinel.igw)])
         get_related_security_configs = Mock(return_value=[str(sentinel.sec_config)])
         get_related_vpc = Mock(return_value=[str(sentinel.vpc)])
-
+        get_related_kms_keys = Mock(return_value=[str(sentinel.kms_key)])
         get_related = Mock(side_effect=get_related_results)
 
     class CredentialReportMixin:
@@ -1108,6 +1108,14 @@ def test_C7N_CELFilter_get_related_vpc(celfilter_instance):
         vpc = celpy.c7nlib.get_related_vpc(ec2_doc)
     assert vpc == [str(sentinel.vpc)]
     assert mock_filter.get_related_vpc.mock_calls == [call(ec2_doc)]
+
+# def test_C7N_CELFilter_get_related_kms_keys(celfilter_instance):
+#     mock_filter = celfilter_instance['the_filter']
+#     ec2_doc = {"ResourceType": "ec2", "InstanceId": "i-123456789"}
+#     with celpy.c7nlib.C7NContext(filter=mock_filter):
+#         vpc = celpy.c7nlib.get_related_kms_keys(ec2_doc)
+#     assert vpc == [str(sentinel.vpc)]
+#     assert mock_filter.get_related_kms_keys.mock_calls == [call(ec2_doc)]
 
 def test_C7N_CELFilter_security_group(celfilter_instance):
     mock_filter = celfilter_instance['the_filter']

--- a/tests/test_c7nlib.py
+++ b/tests/test_c7nlib.py
@@ -1109,13 +1109,13 @@ def test_C7N_CELFilter_get_related_vpc(celfilter_instance):
     assert vpc == [str(sentinel.vpc)]
     assert mock_filter.get_related_vpc.mock_calls == [call(ec2_doc)]
 
-# def test_C7N_CELFilter_get_related_kms_keys(celfilter_instance):
-#     mock_filter = celfilter_instance['the_filter']
-#     ec2_doc = {"ResourceType": "ec2", "InstanceId": "i-123456789"}
-#     with celpy.c7nlib.C7NContext(filter=mock_filter):
-#         vpc = celpy.c7nlib.get_related_kms_keys(ec2_doc)
-#     assert vpc == [str(sentinel.vpc)]
-#     assert mock_filter.get_related_kms_keys.mock_calls == [call(ec2_doc)]
+def test_C7N_CELFilter_get_related_kms_keys(celfilter_instance):
+    mock_filter = celfilter_instance['the_filter']
+    ec2_doc = {"ResourceType": "ec2", "InstanceId": "i-123456789"}
+    with celpy.c7nlib.C7NContext(filter=mock_filter):
+        vpc = celpy.c7nlib.get_related_kms_keys(ec2_doc)
+    assert vpc == [str(sentinel.kms_key)]
+    assert mock_filter.get_related_kms_keys.mock_calls == [call(ec2_doc)]
 
 def test_C7N_CELFilter_security_group(celfilter_instance):
     mock_filter = celfilter_instance['the_filter']


### PR DESCRIPTION
Adding `get_related_kms_keys()`, which is used similarly to the other `get_related_{}()` functions, to enable Custodian CEL expressions to filter by related AWS resources' KMS keys