### PR TITLE
Resolve lark-parser dependency version conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jmespath==0.10.0
-lark-parser==0.11.2
+lark-parser>=0.10.1
 python-dateutil==2.8.1
 pyyaml==5.4.1
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ here = Path(__file__).parent
 
 setup(
     name="cel-python",
-    version='0.1',
+    version='0.1.1',
     description='Pure Python CEL Implementation',
     long_description=(here/"README.rst").read_text(),
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Resolve conflicting dependency versions by using lark-parser versions 0.10.1 or newer, rather than a strict requirement of 0.11.2

Downgrading the version of `lark-parser` doesn't seem to break anything and allows CEL-Python to be implemented in more places, such as Cloud Custodian. Custodian has an underlying dependency on `python-hcl2`, which requires a `0.10.*` version of `lark-parser`