### PR TITLE
Add licensing to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ here = Path(__file__).parent
 
 setup(
     name="cel-python",
-    version='0.1.1',
+    version='0.1.2',
     description='Pure Python CEL Implementation',
     license='Apache-2.0',
     long_description=(here/"README.rst").read_text(),

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     name="cel-python",
     version='0.1.1',
     description='Pure Python CEL Implementation',
+    license='Apache-2.0',
     long_description=(here/"README.rst").read_text(),
     long_description_content_type='text/x-rst',
     author='Cloud Custodian Project',


### PR DESCRIPTION
Specify our Apache 2.0 licensing in our setup.py so tox scans recognize it rather than running into this:
```
Run ./.tox/py39/bin/python tools/dev/license-check.py
cel-python: UNKNOWN []
Error: Process completed with exit code 1.
```