### PR TITLE
update license copyright and packaging info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 Capital One Services, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ here = Path(__file__).parent
 
 setup(
     name="cel-python",
-    version='0.1.2',
+    version='0.1.3',
     description='Pure Python CEL Implementation',
     license='Apache-2.0',
     long_description=(here/"README.rst").read_text(),
@@ -33,10 +33,10 @@ setup(
     author_email=None,
     maintainer=None,
     maintainer_email=None,
-    url='https://cel-python.io',
+    url='https://github.com/cloud-custodian/cel-python',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     package_data={"celpy": ["*.lark"]},
     install_requires=(here/"requirements.txt").read_text().splitlines(),
-    python_requires='>=3.6, <4',
+    python_requires='>=3.7, <4',
 )


### PR DESCRIPTION
Updated copyright information in LICENSE

Fixed URL to link from PyPI page to Github repo

Corrected description to show that we support Python versions >= 3.7, <4