### PR TITLE
Fix pip sdist install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
+include requirements.txt
 prune tests
 prune tools
 prune docs
 prune .vscode
 prune .github
 global-exclude .travis.yml .gitignore .drone.yml .dockerignore .coveragerc
-global-exclude .codecov.yml requirements*txt tox.ini Makefile .azure-piplines.yml
+global-exclude .codecov.yml requirements-dev.txt tox.ini Makefile .azure-piplines.yml


### PR DESCRIPTION
With the current implementation of setup.py the source distribution cannot work because requirements.txt isn't included. This is reproducible with the following command `pip install cel-python --no-binary :all:`.
> FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'

