### PR TITLE
releng - distribution name is cel-python, package is celpy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install-tools:
 
 test:
 	cd features && $(MAKE) all
-	tox -e py39
+	tox -e py312
 
 test-all:
 	cd features && $(MAKE) all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ skip = [
   ]
 
 [tool.poetry]
-name = "celpy"
+name = "cel-python"
 version = "0.2.0"
 description = "Pure Python implementation of Google Common Expression Language"
 authors = ["S. Lott <slott56@gmail.com>"]
@@ -35,6 +35,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python"
 ]
+packages = [{ include = "src/celpy" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION


while uploading 0.2 one issue that came up when publishing was that with the poetry conversion, was the package name and distribution name were both set to celpy,
while the distribution name in pypi is cel-python. adjust the pyproject.toml configuration to reflect that.

