### PR TITLE
Make google-re2 a requirement, not an optional dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,22 +42,19 @@ re2
 ---
 
 CEL specifies that regular expressions use re2 syntax,
-https://github.com/google/re2/wiki/Syntax. To keep its dependencies minimal and
-this implementation easily embeddable, cel-python uses the Python standard
-library ``re`` syntax by default. If a ``re2`` package is installed or the
-``re2`` extra is provided, cel-python will use ``re2`` syntax instead.
+https://github.com/google/re2/wiki/Syntax.
+As of the 0.4.0 release, the Google-RE2 module is part of the CEL distribution.
 
-::
-
-    python -m pip install cel-python[re2]
-
-.. warning:: Apple Silicon
+.. warning:: Apple Silicon and Python 3.13
 
     See https://github.com/google/re2/issues/453,
     https://github.com/google/re2/issues/346,
     https://github.com/google/re2/issues/516
 
-    As of the 0.4.0 release, the google-re2 package does not build for Python 3.13 on the "darwin" platform with the "arm64" architecture.
+    Google-RE2 does not build for Python 3.13 on the "darwin" platform with the "arm64" architecture.
+    Currently, there is no pre-built binary for Python 3.13.
+
+    The built-in ``re`` is used as a fall-back, and does work for all but a few edge cases.
 
 Command Line
 ============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,16 +33,12 @@ dependencies = [
     "pendulum>=3.1.0",
     "pyyaml>=6.0.2",
     "jmespath>=1.0.1",
+    "google-re2>=1.1.20240702 ; python_version!='3.13' or sys_platform!='darwin' or platform_machine!='arm64'",
     "tomli >= 1.1.0 ; python_version < '3.11'",
 ]
 
 [project.scripts]
 cel-python = "cel_python:main"
-
-[project.optional-dependencies]
-re2 = [
-    "google-re2",
-]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/celpy/evaluation.py
+++ b/src/celpy/evaluation.py
@@ -84,13 +84,11 @@ import lark.visitors
 import celpy.celtypes
 from celpy.celparser import tree_dump
 
-_USE_RE2 = False  # Used by the test suite.
 try:
     import re2
 
-    _USE_RE2 = True  # Used by the test suite.
-
     def function_matches(text: str, pattern: str) -> "Result":
+        """Implementation of the ``match()`` function using ``re2``"""
         try:
             m = re2.search(pattern, text)
         except re2.error as ex:
@@ -99,8 +97,12 @@ try:
         return celpy.celtypes.BoolType(m is not None)
 
 except ImportError:  # pragma: no cover
+    # There is a build issue with python_version=='3.13' and sys_platform=='darwin'
+    # See https://github.com/google/re2/issues/516
+    # We fall back to using re, which passes the essential tests
 
     def function_matches(text: str, pattern: str) -> "Result":
+        """Alternative implementation of the ``match()`` function for systems where ``re2`` can't be installed."""
         try:
             m = re.search(pattern, text)
         except re.error as ex:

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -169,7 +169,7 @@ def test_operator_in():
     assert isinstance(operator_in(celtypes.IntType(-1), container_2), CELEvalError)
 
 
-@pytest.mark.skipif(not celpy.evaluation._USE_RE2, reason="Not using RE2")
+@pytest.mark.skipif("re2" not in celpy.evaluation.function_matches.__globals__, reason="Not using RE2")
 def test_function_matches_re2():
     empty_string = celtypes.StringType("")
     # re-specific patterns which behave differently than re2
@@ -177,7 +177,7 @@ def test_function_matches_re2():
     assert isinstance(function_matches(empty_string, "^\\Z"), CELEvalError)
 
 
-@pytest.mark.skipif(celpy.evaluation._USE_RE2, reason="Using RE2")
+@pytest.mark.skipif("re2" in celpy.evaluation.function_matches.__globals__, reason="Using RE2")
 def test_function_matches_re():
     empty_string = celtypes.StringType("")
     # re2-specific patterns which behave differently than standard re

--- a/type_check/lineprecision.txt
+++ b/type_check/lineprecision.txt
@@ -6,6 +6,6 @@ celpy.adapter       142       34          3    9     90           6
 celpy.c7nlib       1663      344         16  152   1151           0
 celpy.celparser     411      138         67   23    183           0
 celpy.celtypes     1480      385         15  234    809          37
-celpy.evaluation   3873     1136        249  244   2228          16
+celpy.evaluation   3875     1134        249  244   2232          16
 xlate                 0        0          0    0      0           0
 xlate.c7n_to_cel   1755      397        103  144   1105           6


### PR DESCRIPTION
Change to the dependencies.

Currently, for Python 3.13 there were no pre-built binaries. For sys_platform=='darwin' and 
platform_machine=='arm64', there's a build error with google-re2; the fallback is to use the built-in re module.