### PR TITLE
Allow google-re2 on 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 env:
   POETRY_VERSION: "1.8.3"
-  DEFAULT_PY_VERSION: "3.12"
+  DEFAULT_PY_VERSION: "3.13"
 
 jobs:
   Lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,8 @@ jobs:
             tox-target: py311
           - python-version: "3.12"
             tox-target: py312
+          - python-version: "3.13"
+            tox-target: py313
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pendulum>=3.1.0",
     "pyyaml>=6.0.2",
     "jmespath>=1.0.1",
-    "google-re2>=1.1.20240702 ; python_version!='3.13' or sys_platform!='darwin' or platform_machine!='arm64'",
+    "google-re2>=1.1.20240702",
     "tomli >= 1.1.0 ; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "pendulum>=3.1.0",
     "pyyaml>=6.0.2",
     "jmespath>=1.0.1",
+    # 3.13 needs at least this version, which started publishing wheels for Python 3.13.
+    # Ref: https://github.com/google/re2/issues/516
+    "google-re2>=1.1.20250722; python_version == '3.13'",
     "google-re2>=1.1.20240702",
     "tomli >= 1.1.0 ; python_version < '3.11'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,9 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.14' or (python_full_version >= '3.11' and python_full_version < '3.13')",
     "python_full_version == '3.10.*'",
     "python_full_version < '3.10'",
 ]
@@ -24,7 +25,8 @@ name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.14' or (python_full_version >= '3.11' and python_full_version < '3.13')",
     "python_full_version == '3.10.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
@@ -69,7 +71,8 @@ name = "cel-python"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
-    { name = "google-re2" },
+    { name = "google-re2", version = "1.1.20240702", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.13.*'" },
+    { name = "google-re2", version = "1.1.20250805", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
     { name = "jmespath" },
     { name = "lark" },
     { name = "pendulum" },
@@ -97,6 +100,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "google-re2", specifier = ">=1.1.20240702" },
+    { name = "google-re2", marker = "python_full_version == '3.13.*'", specifier = ">=1.1.20250722" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "lark", specifier = ">=1.2.2" },
     { name = "pendulum", specifier = ">=3.1.0" },
@@ -333,6 +337,11 @@ wheels = [
 name = "google-re2"
 version = "1.1.20240702"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' or (python_full_version >= '3.11' and python_full_version < '3.13')",
+    "python_full_version == '3.10.*'",
+    "python_full_version < '3.10'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/ea9bfa2afbb6847b7bc7f90ab927dd31fcd7f478062a8a10045059367de1/google_re2-1.1.20240702.tar.gz", hash = "sha256:8788db69f6c93cb229df62c74b2d9aa8e64bf754e9495700f85812afa32efd2b", size = 11626, upload-time = "2024-07-01T14:09:10.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/9b/0fb72635a75405bce9e15fb94f994e59883a2757adda43978fc8eb6dad3e/google_re2-1.1.20240702-1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:46e7ed614ffaafccae017542d68e9bbf664c8c1e5ca37046adee640bbee4846e", size = 464159, upload-time = "2024-07-01T14:07:46.575Z" },
@@ -378,11 +387,76 @@ wheels = [
 ]
 
 [[package]]
+name = "google-re2"
+version = "1.1.20250805"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ed/7caa25b34a201ef8db5a635e03ca71c926caff92aba1b17e86b78190de43/google_re2-1.1.20250805.tar.gz", hash = "sha256:c55d9f7c92a814eb53918a7b38e5ba5eaa1c99548321acb826da9532781af5b5", size = 11698, upload-time = "2025-08-05T19:30:24.345Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/9c/e120dc14daa0b6d5e0ddb659e0f132292abf22fad3563c017b73ab549a01/google_re2-1.1.20250805-1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:7d2a7dea1448733184a99516a41f28ffcfc9eda345697a14fd5c6d8144b60841", size = 483036, upload-time = "2025-08-05T19:29:05.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b6/981ae8734410617c0cb6d32b059a6833ca980bbe6e65840bc8e68f5697ea/google_re2-1.1.20250805-1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:51b4e3c5e6f3f74193666295385b44e1043e55cf98e4b933fe11a0d7a2457a67", size = 514139, upload-time = "2025-08-05T19:29:07.721Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/d1c1c729b7e356dd8b8224bf1873d90fa94c350eddce0ef7da775440a552/google_re2-1.1.20250805-1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0c43d2120ba62e8da4d064dcb5b5c9ac103bfe4cd71a5472055a7f02298b544b", size = 484050, upload-time = "2025-08-05T19:29:09.163Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/78/a07b752d7d879f25b6de12f442ebfd57be9acc79857f16c026ba989afad0/google_re2-1.1.20250805-1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:46eb32ca99136e5ff76b33195b37d41342afcc505f4b60309a4159008f80b064", size = 515591, upload-time = "2025-08-05T19:29:10.742Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4a/651971a6ece6a85ff6598bcf801cb0c7ee20a251b9631b7b5d4886642818/google_re2-1.1.20250805-1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:eaf8b912020ec9bcc1811f64478e2dfb82907e502b718ad4b263045820519595", size = 484613, upload-time = "2025-08-05T19:29:12.348Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ad/8768a99b2b79b14806b7da89f783f6828f540469169066cf3a7bb16cbe44/google_re2-1.1.20250805-1-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:0df2591355131457f9a008b3bd8fbdb104f8344b75d150fd90ddc0bc19b80935", size = 511041, upload-time = "2025-08-05T19:29:13.87Z" },
+    { url = "https://files.pythonhosted.org/packages/68/34/997ee9e113398c5ca6ec8bb5c2d210e7931e44b1fbd38024d09dabd2ba9a/google_re2-1.1.20250805-1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb56c6e7c8fe2eaf045b987dbf8dfc979f61a21e6446dd8b3c0e4028f9ff8611", size = 572722, upload-time = "2025-08-05T19:29:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e2/f99887835200a961a957dab4208d00ae344a8906ed9e0bb1ce578aec87a1/google_re2-1.1.20250805-1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7f2124ccc4e06c1841e18360edbc379f050b8dcb54096293e2e6e90b5f913f92", size = 588956, upload-time = "2025-08-05T19:29:16.975Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fc/bd56b2133ce1d6853e4abafa89685860eda725a2fe62c233a30cfe928abb/google_re2-1.1.20250805-1-cp310-cp310-win32.whl", hash = "sha256:0bcf2acdc32a3890ddfca87fa846806b6db200a059a83ab114e6ab390beaf10e", size = 432851, upload-time = "2025-08-05T19:29:18.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ac/21473b4de4a829bc9822d810fc1a26c7abdbee76c60a915a8ade0dae6372/google_re2-1.1.20250805-1-cp310-cp310-win_amd64.whl", hash = "sha256:8c6da22b158459e5a592fcd66a9e99347f517284d91d61b6ff2befff3eb79339", size = 490154, upload-time = "2025-08-05T19:29:19.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6f/c99a04f13114282362bf73dd1a79e96b92ed80ed47bf1f57744646753e08/google_re2-1.1.20250805-1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:e7f7e960002c702ae2c0aff3b8db895ded37006ac7aa0c158743fb20dcd485c2", size = 483730, upload-time = "2025-08-05T19:29:21.181Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c8/994a5fef87eb977d06ff8dfe7bb59ba31f535d3f2622334b6b32f1b65528/google_re2-1.1.20250805-1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:bfacaa9b274871796bfd0750e23f804ff632a5397b830c640449d3d57b3d148f", size = 515513, upload-time = "2025-08-05T19:29:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/30/25/81672efc1d0cce43813e0b3bffc14c3d32e102cf254c9d280bf4e5194664/google_re2-1.1.20250805-1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c4f72b275ec6b5ef6e3215dab9392aefc2e8f8590d0c3d8b266e6a913503d2a1", size = 485374, upload-time = "2025-08-05T19:29:23.925Z" },
+    { url = "https://files.pythonhosted.org/packages/da/04/7a3361618217d401203a9eb34712c824e9645f7d2830d1e804eb9859374c/google_re2-1.1.20250805-1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:c6b5550a9767e444b17a9c3c4b020c51629282748d77244d833aacbd765f28fe", size = 517105, upload-time = "2025-08-05T19:29:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/38/97/29e8097e449b0af993acd7d7d658ecfac3914ac501e6c6d40ffcebc03b8e/google_re2-1.1.20250805-1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4c1e5ec68dfe2e0866f14468600e2e2928dcfe684c0f2fbeda8d16f14f909141", size = 485756, upload-time = "2025-08-05T19:29:26.975Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/88/cb3647eb92c991d93fde8b1fefddd52ff3bb45a5d1c20185e2fd24e1e5fa/google_re2-1.1.20250805-1-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:336d6830888ea2abdc1744d201e19cf76c4f001cf821bed3e8844c1899bcbdaf", size = 512227, upload-time = "2025-08-05T19:29:28.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fe/33e357bb8d090a4879e9e257be577740d1b5d762686b4fa448f050b15caf/google_re2-1.1.20250805-1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a153ce37ccfd5429257a91d68f4338fe2809711bff64c7ab84c97ddef2de25", size = 573694, upload-time = "2025-08-05T19:29:29.52Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/e1648859b140b76717319a8d8aceec3365e354ea9ff0690d0fbbcb5774e3/google_re2-1.1.20250805-1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ffc79fe2f4be9c5e3e8bb04c8e84e0c9a27b5f08ad5103779b084005e99d220", size = 590760, upload-time = "2025-08-05T19:29:30.967Z" },
+    { url = "https://files.pythonhosted.org/packages/af/0a/1dae50eece5fe4f53503f47f8535ee7f8667e2f84dbbf87f0fa8942678b6/google_re2-1.1.20250805-1-cp311-cp311-win32.whl", hash = "sha256:2cfccbbd8577250406a3a3ff1b5d3ee21a479e3f1a01f78042d4d15c461eca1e", size = 434080, upload-time = "2025-08-05T19:29:32.578Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b8/1c4e100d2b1dac7c4ab52d18b8c3060a835f1e2b9dc0802024313fa69277/google_re2-1.1.20250805-1-cp311-cp311-win_amd64.whl", hash = "sha256:4d0669fed9f9f993c5cffae42d7193da752e5b4e42e95b0e9ee0b95de9fcd8ad", size = 490954, upload-time = "2025-08-05T19:29:33.784Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ac/3ed55b2f70cb1b091a59c5242376524e68de88d0280ea0be7c8f4754a37d/google_re2-1.1.20250805-1-cp311-cp311-win_arm64.whl", hash = "sha256:50495e5f783e0c1577384bac75455a799904158b5077284c70e6a9510995f3be", size = 642137, upload-time = "2025-08-05T19:29:34.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/5ed6ffcb1f33348e7f212819d1082f125bd224c89aef842b78b63f9a97e0/google_re2-1.1.20250805-1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:39f81ff026701533593ffb43acd999d11b8ff769d2234e2083c9ae38d02a01a4", size = 485610, upload-time = "2025-08-05T19:29:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e3/b4db34e633b0c5c880c2a3371eedcab600ea0c04a51a2509cda09c913e1e/google_re2-1.1.20250805-1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:7d26aecd8850ec469bf8ae7d3a1ad26b1b1c0477400351ff5df181ef5dff68f0", size = 518722, upload-time = "2025-08-05T19:29:37.51Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/96/ca6f0ff5693558ba104007cf7cc8187d3d47c5d01af06c4204bbe9d8d160/google_re2-1.1.20250805-1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:f45314ef7b22c28a1c43469d522398068af4bd1b59839c831033723c782c7402", size = 486962, upload-time = "2025-08-05T19:29:38.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e5/41e316d9a160bca99f7a4bff2dc9f4a9b8a3b3b927a610fdf7717f0af2f7/google_re2-1.1.20250805-1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:13e8b83655fcb97d7190d8c07a2886dd5bf9c55935419c98a4b7f09cc6e2019d", size = 520209, upload-time = "2025-08-05T19:29:39.967Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c6/30d8c5988c640d6de7a9b0739bc33d9b2a4d00bf12a7e6c0abfebc0c365b/google_re2-1.1.20250805-1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:9c17c678b3bf2ca874c74b898a21b534d3e60123eda8ef18dde1c1932d142b1f", size = 487152, upload-time = "2025-08-05T19:29:41.596Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1f/d3f04e5c66c2bf235cb449f4e7372596375f6a8537eaeaa35f076927bd0b/google_re2-1.1.20250805-1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:a848f44752286372cfb0ff225a836ed7b02738b29ca31ed3c58e70dc7d584537", size = 514497, upload-time = "2025-08-05T19:29:43.196Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e3/14c2999896aa5bc111a18fe41c56283f222179076c52d515ea5c3e0043ad/google_re2-1.1.20250805-1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a90f090081e415ee182a01f4113076ad5707c5501ae985c8edc5bfc439cbdee6", size = 572418, upload-time = "2025-08-05T19:29:44.478Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ad/7c4e61bccbfaf036011960ebbc8743971a34f1bd1b07d1f379b2feb81296/google_re2-1.1.20250805-1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b5749bcbb363cdfdff5da14aa0c53de28f918662d0b6f546af31f96c8fd46dd", size = 591359, upload-time = "2025-08-05T19:29:46.186Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fe/f1a0966c76a52467879f951ba1ffbbc5f2a4a0ecc2f2c2e40b131613b9e9/google_re2-1.1.20250805-1-cp312-cp312-win32.whl", hash = "sha256:19689531ce9839813035663df68aa49074c92e426b20095e5e665521c55c1cab", size = 433756, upload-time = "2025-08-05T19:29:47.416Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/27/f20d98d5121479eed67127eafb3ed99531d9bc43fac2e75e04938950b2ca/google_re2-1.1.20250805-1-cp312-cp312-win_amd64.whl", hash = "sha256:b533077b8a1c120c5f446e6734893d2a18d098e3edde149dda6a9ff9a3e2e7d2", size = 491663, upload-time = "2025-08-05T19:29:48.726Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5a/8997a1e00fcd75db5a6c1243ee512f174a2e266f0017d2a209de36007cef/google_re2-1.1.20250805-1-cp312-cp312-win_arm64.whl", hash = "sha256:3a0193237b274faf57492efbeecc9be5818f3852f186ea5c672490b49da4d124", size = 642623, upload-time = "2025-08-05T19:29:50.172Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c0/f4b5c894335bc7d276e5be58d72e24811db8d5900dfdf37069528d65b73c/google_re2-1.1.20250805-1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:049732fce70dea6246f035027e512f7cbc22fa9c7f2969c503cd0abb0fcfc674", size = 485546, upload-time = "2025-08-05T19:29:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a8/afcddbf964add57569cc0081e99fc968e1bc9d65c34612e0a63ec2085606/google_re2-1.1.20250805-1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:552e37f08514778d98b6d27aea2abd80efca19c4812ca6388175fd5e54d08229", size = 518842, upload-time = "2025-08-05T19:29:52.826Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a4/82063779d7c6c56136b8217c022f6d95c490d73ccc78ca5e57158fd91855/google_re2-1.1.20250805-1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6d452dab6bd9dedecef4cc4a0ba22203f5c4273395fd7896fe9ed0cc85643b11", size = 487043, upload-time = "2025-08-05T19:29:54.526Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/06/aee9f7315c00c77e1f3653d44a356c68c2066bc1de516c1bd473b6d827c5/google_re2-1.1.20250805-1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:358f497682cb5d57f0dd107944f7a2167226d31fb5211cfd187ec16cb5275355", size = 520233, upload-time = "2025-08-05T19:29:55.8Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7f/d28e64ce85604635da2870c99ac8c8c3e078aaba1f132ecea239f65f0030/google_re2-1.1.20250805-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:af66c822179f7f412e4c1fcc8b5ca84885e24ba77c2ee8aa7364f19131b77e7d", size = 487233, upload-time = "2025-08-05T19:29:57.531Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/bc22d185861461aafa8e8193a1e22f9eac1217e9bec9ac34b681f1c10bd9/google_re2-1.1.20250805-1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:555b6183fa1a6f54117ec0eda333b98d96620c5d59b563a1dbe2a3eddf64ca24", size = 514473, upload-time = "2025-08-05T19:29:58.826Z" },
+    { url = "https://files.pythonhosted.org/packages/56/05/a6da22582817396e30931e0d292d2ef4819c2eea3fb21b08661f9a6f3106/google_re2-1.1.20250805-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7dfeab6a641a8e6c8ac1cb7fa40b4d2cb91571a3c4bcc840a6d1245d37c33bb", size = 572370, upload-time = "2025-08-05T19:30:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/14/feb54f3f11522f334294a916dffb54ab36dfaba47c7c8d0e091aec1084f1/google_re2-1.1.20250805-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b328e6d75e7b1e161dd834c42a7e1762d2e03919453257a64712a5bda798226", size = 591407, upload-time = "2025-08-05T19:30:01.62Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b2/7c785a0596e8535794b5c21d27c3081928748acd556a4a0ef3b2c8338881/google_re2-1.1.20250805-1-cp313-cp313-win32.whl", hash = "sha256:eb1c398eaec3c8ffe74fe7064008c81f452ca5bdf12c2538acc4c087d043a6e1", size = 433845, upload-time = "2025-08-05T19:30:03.46Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/1d/af1fc1a5247d6549e67716bcb5e790761bb550026e659dfcfd89408389fd/google_re2-1.1.20250805-1-cp313-cp313-win_amd64.whl", hash = "sha256:18f72952c71de0ace48fbe0ca9928bd7b7bbe1062f685c0d1326a0205966f2dc", size = 491718, upload-time = "2025-08-05T19:30:05.14Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/89/39fd1d16a9cbda45cf55b920fac4840fc16ca668b96333f1a5d8931e1ec0/google_re2-1.1.20250805-1-cp313-cp313-win_arm64.whl", hash = "sha256:149ec3ce1a4711daf45aab4fc7d5926f9e3082ee2c6ea138043c27e64ff1d782", size = 642609, upload-time = "2025-08-05T19:30:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/21/68bbd19e9657154e61d89263344a3f192f693dd9262405818d6f2aa1c62a/google_re2-1.1.20250805-1-cp39-cp39-macosx_13_0_arm64.whl", hash = "sha256:1cb729cba2c6d31c325a6f485119c087828033eba6f9b49f2fa7fb922f01fe75", size = 483102, upload-time = "2025-08-05T19:30:08.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a0/61802fa83d85c202f4cca2d2f75349aa427c9f635f00869c23a01139716c/google_re2-1.1.20250805-1-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:10366ae2b7de70793a39c9c5c906828674b25d014685c0c162cc29dd21a312e3", size = 514210, upload-time = "2025-08-05T19:30:09.491Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/3dda1b03879f064fd6d0c953b8ba7543653602b6788b8927ceb92a84618c/google_re2-1.1.20250805-1-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:486467c4defdeaea5988f368a29596accf74c89a249906152f4be68038349234", size = 484051, upload-time = "2025-08-05T19:30:11.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/5e5868fe3b5e52369d2c3e7ea581d36c5bcc9811fd6cd705212cce05533a/google_re2-1.1.20250805-1-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:df12b5575e63c1c53ccefef03ff7994aa693ae8dc80eede2e8e6abc4ee351b37", size = 515717, upload-time = "2025-08-05T19:30:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e1/39b724953c179034a3cf311dc09dd59cf241dac5b7c0aad84228788e188a/google_re2-1.1.20250805-1-cp39-cp39-macosx_15_0_arm64.whl", hash = "sha256:8da72200c0a2cf91332058137c9288074188bcb30f015ad3358be1aea8a042a6", size = 484744, upload-time = "2025-08-05T19:30:13.96Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/dfc7ce9dac77f0537078e6bd83a4a197660aca0261dc42e017813acaa90b/google_re2-1.1.20250805-1-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:76176818b2c0cc77dfbe13c8067744ceb88d38c1b5eb8c517e29b875ab36fdb1", size = 511102, upload-time = "2025-08-05T19:30:15.197Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a2/d21c5d112bf8f787557bc2cdcb894e3015e9f06dcf6e7d0e88e7c1aaf0a4/google_re2-1.1.20250805-1-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f763fdb3ca87e718f1c529188f119d84d6378f490c93b25c3b4719b4c848319a", size = 573077, upload-time = "2025-08-05T19:30:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ca/1a326101a1b2524d3dd08c3a18cfd028cdc4a766637fe5009e8c10fe385c/google_re2-1.1.20250805-1-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a225474f2f985cd8f93a133dd8d0288cd6f19827279a19838b5147f61a5a688", size = 589458, upload-time = "2025-08-05T19:30:20.546Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/63/c0d535b10b7f8ee1e8572b0b2c9e682c39caf78c1fdcdc5f79d8be317f03/google_re2-1.1.20250805-1-cp39-cp39-win32.whl", hash = "sha256:90d2fe1a1b1a05d49c3bbc88510dfe5f7b6e9325c48b4e079fc84fb09ad1b043", size = 433553, upload-time = "2025-08-05T19:30:21.817Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ec/83546e532d74931c28e1711a259f2205f63e27e80ce5398c411a7f600c59/google_re2-1.1.20250805-1-cp39-cp39-win_amd64.whl", hash = "sha256:65dca27d5a65ee478c00ec8d4080ada680ada7d30552f91fe515ac57b18689bc", size = 497279, upload-time = "2025-08-05T19:30:23.132Z" },
+]
+
+[[package]]
 name = "google-re2-stubs"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-re2" },
+    { name = "google-re2", version = "1.1.20240702", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.13.*'" },
+    { name = "google-re2", version = "1.1.20250805", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/a4/d8d16007eb6a6eb137ec3b6344a67199837e14a73709efeaa7285d2660eb/google_re2_stubs-0.1.1.tar.gz", hash = "sha256:f5ebef2f4188957bf980a5ad88ab266589638e5090329e6a0fde99f6bb684657", size = 4009, upload-time = "2024-10-21T15:22:43.861Z" }
 wheels = [
@@ -942,7 +1016,8 @@ name = "sphinx"
 version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version == '3.13.*'",
+    "python_full_version >= '3.14' or (python_full_version >= '3.11' and python_full_version < '3.13')",
 ]
 dependencies = [
     { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -69,16 +69,12 @@ name = "cel-python"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "google-re2" },
     { name = "jmespath" },
     { name = "lark" },
     { name = "pendulum" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-
-[package.optional-dependencies]
-re2 = [
-    { name = "google-re2" },
 ]
 
 [package.dev-dependencies]
@@ -100,14 +96,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "google-re2", marker = "extra == 're2'" },
+    { name = "google-re2", specifier = ">=1.1.20240702" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "lark", specifier = ">=1.2.2" },
     { name = "pendulum", specifier = ">=3.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
 ]
-provides-extras = ["re2"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
There is [now a wheel for Python 3.13][1], so this specifier is no longer needed.

I think this ought to fix #120, but we may also want/need to bump the basepython in [tox.ini](https://github.com/stefanvanburen/cel-python/blob/svanburen/remove-re2-specifiers/tox.ini) to `py313` as well?

[1]: https://github.com/google/re2/issues/516