### PR TITLE
Fix case mismatch in behave step

### DIFF
--- a/features/steps/cli_binding.py
+++ b/features/steps/cli_binding.py
@@ -34,7 +34,7 @@ import parse
 from behave import *
 
 
-@given(u'JSON Document \'{json}\'')
+@given(u'JSON document \'{json}\'')
 def step_impl(context, json):
     context.data['json'].append(json)
 


### PR DESCRIPTION
Behave 1.3.0 introduced a breaking change where the default matcher became case sensitive.