### PR TITLE
Add license information to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ name = "cel-python"
 version = "0.4.0"
 description = "Pure Python implementation of Google Common Expression Language"
 readme = "README.rst"
+license = "Apache-2.0"
 license-files = ["LICENSE"]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
```shell
user@PC:~ $ pip-licenses | grep cel
 cel-python                     0.4.0            UNKNOWN
 ```
 
pip-licenses shows that cel-python has no license, but I see you have the Apache-2.0 license set on the repo. Looking into it I think you have to add the `license` key to your pyproject.toml file as per this list of examples: https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/
 
 