### PR TITLE
fix: use EAFP try/except for os.getegid/geteuid in stat() (issue #177)

### DIFF
--- a/src/celpy/__main__.py
+++ b/src/celpy/__main__.py
@@ -259,7 +259,6 @@ def stat(path: Union[Path, str]) -> Optional[celtypes.MapType]:
             data["user_access"] = celtypes.BoolType(status.st_uid == os.geteuid())
         except AttributeError:
             pass
-        }
 
         # From mode File type:
         # - block, character, directory, regular, symbolic link, named pipe, socket

--- a/src/celpy/__main__.py
+++ b/src/celpy/__main__.py
@@ -253,8 +253,12 @@ def stat(path: Union[Path, str]) -> Optional[celtypes.MapType]:
             "st_ino": celtypes.IntType(status.st_ino),
             "st_nlink": celtypes.IntType(status.st_nlink),
             "st_size": celtypes.IntType(status.st_size),
-            "group_access": celtypes.BoolType(status.st_gid == os.getegid()),
-            "user_access": celtypes.BoolType(status.st_uid == os.geteuid()),
+                    }
+        try:
+            data["group_access"] = celtypes.BoolType(status.st_gid == os.getegid())
+            data["user_access"] = celtypes.BoolType(status.st_uid == os.geteuid())
+        except AttributeError:
+            pass
         }
 
         # From mode File type:

--- a/src/celpy/__main__.py
+++ b/src/celpy/__main__.py
@@ -253,7 +253,7 @@ def stat(path: Union[Path, str]) -> Optional[celtypes.MapType]:
             "st_ino": celtypes.IntType(status.st_ino),
             "st_nlink": celtypes.IntType(status.st_nlink),
             "st_size": celtypes.IntType(status.st_size),
-                    }
+        }
         try:
             data["group_access"] = celtypes.BoolType(status.st_gid == os.getegid())
             data["user_access"] = celtypes.BoolType(status.st_uid == os.geteuid())


### PR DESCRIPTION
Replace LBYL platform check with EAFP try/except AttributeError pattern.

os.getegid() and os.geteuid() are unavailable on Windows and other non-POSIX platforms (e.g. WASI), raising AttributeError. Rather than checking the platform up front, wrap the assignments in a try/except block so group_access and user_access are simply omitted when the underlying OS calls are not available.

Closes #177